### PR TITLE
Check for anchors as parents instead of only the event.target in the router

### DIFF
--- a/src/theme/scripts/router.js
+++ b/src/theme/scripts/router.js
@@ -34,8 +34,10 @@ class Router {
   }
 
   async _onLinkClick(event) {
-    if(event.target.tagName !== 'A') return;
-    const link = new URL(event.target.href);
+    // See if what is clicked has an anchor as parent or is a link itself and create an URL of it
+    const link = event.target.closest('a') ? new URL(event.target.closest('a').href) : null;
+    if (!link) return;
+
     // If it’s an external link, just navigate.
     if(link.host !== this._hostname) {
       return;

--- a/src/theme/scripts/router.js
+++ b/src/theme/scripts/router.js
@@ -34,9 +34,10 @@ class Router {
   }
 
   async _onLinkClick(event) {
-    // See if what is clicked has an anchor as parent or is a link itself and create an URL of it
-    const link = event.target.closest('a') ? new URL(event.target.closest('a').href) : null;
-    if (!link) return;
+    // See if what is clicked has an anchor as parent or is a link itself. If so create URL otherwise return.
+    const linkElement = event.target.closest('a');
+    if (!linkElement) return;
+    const link = new URL(linkElement.href);
 
     // If it’s an external link, just navigate.
     if(link.host !== this._hostname) {


### PR DESCRIPTION
When someone builds up html like `<a><h1></h1></a>` or  `<a>Some <strong>text</stong></a>`the event.target.tagName would return 'H1' or 'STRONG' instead of 'A' so the app would refresh instead of using the router. By checking for the targeted tag's ancestors any link would come up even if a complete div would have to function as a thumbnail. Because links may not be nested the parent link would always be the correct link.